### PR TITLE
Bump reqwest and others

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ regex = "1.12"
 
 [dev-dependencies]
 tokio = { version = "1.46", features = ["macros", "rt"] }
-biblatex = "0.10"
+biblatex = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["doi", "bibtex", "bibliography", "biblatex"]
 
 [dependencies]
 reqwest = "0.13"
-regex = "1.11"
+regex = "1.12"
 
 [dev-dependencies]
 tokio = { version = "1.46", features = ["macros", "rt"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = []
 keywords = ["doi", "bibtex", "bibliography", "biblatex"]
 
 [dependencies]
-reqwest = "0.12"
+reqwest = "0.13"
 regex = "1.11"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ reqwest = "0.13"
 regex = "1.12"
 
 [dev-dependencies]
-tokio = { version = "1.46", features = ["macros", "rt"] }
+tokio = { version = "1.48", features = ["macros", "rt"] }
 biblatex = "0.11"


### PR DESCRIPTION
Note that request 0.13 switched to rustls by default, see
https://seanmonstar.com/blog/reqwest-v013-rustls-default/ for more
details.